### PR TITLE
3070: Allow setting individual tags for API, Admin and Client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,9 @@ COMPOSE_SERVER_DOMAIN=demo.os2display.dk
 COMPOSE_ADMIN_CLIENT_PATH=/admin
 COMPOSE_SCREEN_CLIENT_PATH=/screen
 
-COMPOSE_VERSION=latest
+COMPOSE_VERSION_API=latest
+COMPOSE_VERSION_ADMIN=latest
+COMPOSE_VERSION_CLIENT=latest
 
 ##### api [itkdev/os2display-api-service] #####
 

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -9,7 +9,7 @@ networks:
 
 services:
   api:
-    image: itkdev/os2display-api-service:${COMPOSE_VERSION}
+    image: itkdev/os2display-api-service:${COMPOSE_VERSION_API}
     restart: unless-stopped
     networks:
       - app
@@ -62,7 +62,7 @@ services:
       - ./media:/var/www/html/public/media:rw
 
   nginx-api:
-    image: itkdev/os2display-api-service-nginx:${COMPOSE_VERSION}
+    image: itkdev/os2display-api-service-nginx:${COMPOSE_VERSION_API}
     restart: unless-stopped
     networks:
       - app
@@ -94,7 +94,7 @@ services:
       - ./media:/var/www/html/public/media:rw
 
   admin:
-    image: itkdev/os2display-admin-client:${COMPOSE_VERSION}
+    image: itkdev/os2display-admin-client:${COMPOSE_VERSION_ADMIN}
     restart: unless-stopped
     networks:
       - app
@@ -119,7 +119,7 @@ services:
       # - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.middlewares=ITKBasicAuth@file"
 
   client:
-    image: itkdev/os2display-client:${COMPOSE_VERSION}
+    image: itkdev/os2display-client:${COMPOSE_VERSION_CLIENT}
     restart: unless-stopped
     networks:
       - app


### PR DESCRIPTION
[Ticket](https://leantime.itkdev.dk/tickets/showKanban?search=true&projectId=27&users=14&sprint=all#/tickets/showTicket/3070)

Allow setting individual release tags for API/Nginx, Admin, Client images